### PR TITLE
update corr:message pubsub to use a redis key instead

### DIFF
--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -1,5 +1,5 @@
 """HERA MC class."""
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import time
 import redis

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -102,7 +102,7 @@ class HeraCorrCM(object):
 
     def _send_message(self, command, **kwargs):
         """
-        Send a command to the correlator via the corr:message pub-sub channel.
+        Send a command to the correlator via the corr:command key in redis.
 
         Args:
             command: correlator command
@@ -114,14 +114,9 @@ class HeraCorrCM(object):
         message = json.dumps({"command": command,
                               "time": time.time(),
                               "args": kwargs})
-        listeners = self.r.publish("corr:message", message)
-        if listeners == 0:
-            self.logger.error("Sent command {cmd} "
-                              "but no-one is listening!".format(cmd=command)
-                              )
-            return None
-        else:
-            return message
+        self.r.set("corr:command", message)
+
+        return message
 
     def is_recording(self):
         """

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -1,5 +1,5 @@
 """Handler for correlator for M&C."""
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import logging
 import redis
@@ -50,8 +50,9 @@ class HeraCorrHandler(object):
                 else:
                     return
             else:
+                # The daemon has probably been restarted.
+                # Do no execure the last command but log execution time
                 self.last_command_time = command_time
-                self._cmd_handler(message)
 
         return
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -41,17 +41,17 @@ class HeraCorrHandler(object):
     def process_command(self):
         """Pass command to handler."""
         message = self.r.get("corr:command")
-
-        command_time = float(json.loads(message)["time"])
-        if self.last_command_time is not None:
-            if command_time > self.last_command_time:
+        if message is not None:
+            command_time = float(json.loads(message)["time"])
+            if self.last_command_time is not None:
+                if command_time > self.last_command_time:
+                    self.last_command_time = command_time
+                    self._cmd_handler(message)
+                else:
+                    return
+            else:
                 self.last_command_time = command_time
                 self._cmd_handler(message)
-            else:
-                return
-        else:
-            self.last_command_time = command_time
-            self._cmd_handler(message)
 
         return
 

--- a/scripts/hera_corr_cmd_handler.py
+++ b/scripts/hera_corr_cmd_handler.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     from hera_corr_cm.hera_corr_handler import HeraCorrHandler
 
     parser = argparse.ArgumentParser(description='Process commands from the '
-                                                 'corr:message redis channel.',
+                                                 'corr:command redis key.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-r', dest='redishost', type=str, default='redishost',
                         help='Hostname of redis server')

--- a/scripts/hera_corr_log_cm_bridge.py
+++ b/scripts/hera_corr_log_cm_bridge.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import argparse
 import logging
 import redis
 import socket
 import json
-from .handlers import add_default_log_handlers
+from hera_corr_cm.handlers import add_default_log_handlers
 from hera_mc import mc
 
 hostname = socket.gethostname()

--- a/scripts/hera_corr_log_cm_bridge.py
+++ b/scripts/hera_corr_log_cm_bridge.py
@@ -9,6 +9,7 @@ import socket
 import json
 from hera_corr_cm.handlers import add_default_log_handlers
 from hera_mc import mc
+from astropy.time import Time
 
 hostname = socket.gethostname()
 
@@ -55,7 +56,7 @@ while(True):
             try:
                 decoded = json.loads(mess["data"])
                 msg = decoded['formatted']
-                logtime = self.Time(time.time(), format="unix")
+                logtime = Time.now()
                 msg_level = decoded['levelno']
                 if msg_level >= level:
                     # Re-code level because HeraMC logs 1 as most severe, and python logging calls critical:50, debug:10


### PR DESCRIPTION
Moves away from pubsub channel in favor of a `corr:command` key in redis. The command handler will check that the issue time of the command is newer than the last command run before sending the command to the rest of the correlator.