### PR TITLE
Cmd response update

### DIFF
--- a/hera_corr_cm/handlers.py
+++ b/hera_corr_cm/handlers.py
@@ -96,7 +96,7 @@ def add_default_log_handlers(logger, redishostname='redishost', fglevel=logging.
     syslog_handler.setFormatter(formatter)
     logger.addHandler(syslog_handler)
 
-    redis_host = redis.StrictRedis(redishostname, socket_timeout=1)
+    redis_host = redis.StrictRedis(redishostname, socket_timeout=1, decode_responses=True)
     try:
         redis_host.ping()
     except redis.ConnectionError:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -94,13 +94,14 @@ class HeraCorrCM(object):
             # message = self.corr_resp_chan.get_message(timeout=timeout)
             command_status = self.r.hgetall("corr:cmd_status")
             if command_status == {}:
-                self.logger.error(
+                self.logger.warning(
                     "Command status dict is blank. "
                     "This should not happen durring command execution. "
                     "Someone may have manually deleted it."
                 )
-                self.logger.error("Unknown Command Status dict state.")
-                return
+                self.logger.warning("Unknown Command Status dict state.")
+                time.sleep(1)
+                continue
             # try:
             #     message = json.loads(message["data"])
             # except:
@@ -124,11 +125,12 @@ class HeraCorrCM(object):
                 elif command_status[b"status"] == b"complete":
                     return command_status[b"args"]
 
-            elif (command_status[b"command"] != target_cmd) and (
+            elif (command_status[b"command"] != target_cmd) or (
                 command_status[b"status"] in [b"completed", b"errored"]
             ):
                 # probably an older command just keep reading for now
                 continue
+                time.sleep(1)
             else:
                 self.logger.warning("Received a correlator response that wasn't meant for us")
 

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -91,19 +91,19 @@ class HeraCorrCM(object):
         # This loop only gets activated if we get a response which
         # isn't for us.
         while(True):
+            # sleep for 1s between each attempt
+            time.sleep(1)
             # message = self.corr_resp_chan.get_message(timeout=timeout)
             command_status = self.r.hgetall("corr:cmd_status")
             # bool of a dict is False if the dict is empty
             if not bool(command_status):
                 # command dict was read while correlator was creating a new status
-                time.sleep(1)
                 continue
 
             try:
                 response = json.loads(command_status[b"args"])
             except KeyError:
                 self.logger.warning("Improperly formatted response received. Trying again.")
-                time.sleep(1)
                 continue
 
             if (command_status[b"command"] == target_cmd) and (
@@ -128,10 +128,10 @@ class HeraCorrCM(object):
                 command_status[b"status"] in [b"completed", b"errored"]
             ):
                 # probably an older command just keep reading for now
-                time.sleep(1)
                 continue
             else:
                 self.logger.warning("Received a correlator response that wasn't meant for us")
+                continue
 
     def _send_message(self, command, **kwargs):
         """

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -93,20 +93,11 @@ class HeraCorrCM(object):
         while(True):
             # message = self.corr_resp_chan.get_message(timeout=timeout)
             command_status = self.r.hgetall("corr:cmd_status")
-            if command_status == {}:
-                self.logger.warning(
-                    "Command status dict is blank. "
-                    "This should not happen durring command execution. "
-                    "Someone may have manually deleted it."
-                )
-                self.logger.warning("Unknown Command Status dict state.")
+            # bool of a dict is False if the dict is empty
+            if not bool(command_status):
+                # command dict was read while correlator was creating a new status
                 time.sleep(1)
                 continue
-            # try:
-            #     message = json.loads(message["data"])
-            # except:
-            #     self.logger.warning("Got a non-JSON message on the correlator response channel")
-            #     continue
 
             if (command_status[b"command"] == target_cmd) and (
                 float(command_status[b"time"]) == target_time
@@ -129,8 +120,8 @@ class HeraCorrCM(object):
                 command_status[b"status"] in [b"completed", b"errored"]
             ):
                 # probably an older command just keep reading for now
-                continue
                 time.sleep(1)
+                continue
             else:
                 self.logger.warning("Received a correlator response that wasn't meant for us")
 

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -272,7 +272,7 @@ class HeraCorrCM(object):
             return ERROR
         return OK
 
-    def phase_switch_disable(self, timeout=10):
+    def phase_switch_disable(self, timeout=None):
         """
         Disable phase switching.
 
@@ -283,7 +283,7 @@ class HeraCorrCM(object):
         sent_message = self._send_message("phase_switch", activate=False)
         if sent_message is None:
             return ERROR
-        response = self._get_response(sent_message)
+        response = self._get_response(sent_message, timeout=timeout)
         if response is None:
             return ERROR
         if not self.phase_switch_is_on()[0]:
@@ -385,7 +385,7 @@ class HeraCorrCM(object):
         sent_message = self._send_message("start")
         if sent_message is None:
             return ERROR
-        response = self._get_response(sent_message, timeout=300)
+        response = self._get_response(sent_message)
         if response is None:
             return ERROR
         return OK

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -113,7 +113,9 @@ class HeraCorrCM(object):
                     else:
                         continue
                 elif command_status["status"] == "errored":
-                    self.logger.info("Command errored on execution.")
+                    self.logger.error("Command {} errored on execution.".format(target_cmd))
+                    if "err" in command_status["args"]:
+                        self.logger.error(command_status["err"])
                     return
                 elif command_status["status"] == "complete":
                     return command_status["args"]
@@ -409,9 +411,6 @@ class HeraCorrCM(object):
         response = self._get_response(sent_message)
         if response is None:
             return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
-            return ERROR
         if (ant is not None) or (not self.noise_diode_is_on()[0] and not self.load_is_on()[0]):
             return OK
         return ERROR
@@ -436,9 +435,6 @@ class HeraCorrCM(object):
             return ERROR
         response = self._get_response(sent_message)
         if response is None:
-            return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
             return ERROR
         if (ant is not None) or (self.noise_diode_is_on()[0] and not self.load_is_on()[0]):
             return OK
@@ -476,9 +472,6 @@ class HeraCorrCM(object):
             return ERROR
         response = self._get_response(sent_message)
         if response is None:
-            return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
             return ERROR
         if (ant is not None) or (self.load_is_on()[0] and not self.noise_diode_is_on()[0]):
             return OK
@@ -534,9 +527,6 @@ class HeraCorrCM(object):
         response = self._get_response(sent_message)
         if response is None:
             return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
-            return ERROR
         return OK
 
     def get_eq_coeffs(self, ant, pol):
@@ -584,9 +574,6 @@ class HeraCorrCM(object):
         response = self._get_response(sent_message)
         if response is None:
             return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
-            return ERROR
         if "val" not in response:
             return ERROR
         return response["val"]
@@ -607,9 +594,6 @@ class HeraCorrCM(object):
             return ERROR
         response = self._get_response(sent_message)
         if response is None:
-            return ERROR
-        if "err" in response:
-            self.logger.error(response["err"])
             return ERROR
         return OK
 

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -12,9 +12,6 @@ import numpy as np
 from .handlers import add_default_log_handlers
 from . import __package__, __version__
 
-OK = True
-ERROR = False
-
 N_CHAN = 16384
 SAMPLE_RATE = 500e6
 
@@ -361,7 +358,7 @@ class HeraCorrCM(object):
         Restart (power cycle) the correlator.
 
         Returning it to the settings in the current configuration. Will reset ADC
-        delay calibrations.  Returns OK or ERROR
+        delay calibrations.  Returns True or False
         """
         stop_stat = self._stop()
         start_stat = self._start()
@@ -407,7 +404,7 @@ class HeraCorrCM(object):
         inputs:
             ant (integer): HERA antenna number to switch to antenna. Set to None for all antennas.
         returns:
-            ERROR or OK
+            False or True
         """
         if (ant is not None) and (not isinstance(ant, int)):
             self.logger.error("Invalid `ant` argument. Should be integer or None")
@@ -432,7 +429,7 @@ class HeraCorrCM(object):
             ant (integer): HERA antenna number to switch to noise. Set to None to
                            switch all antennas.
         returns:
-            ERROR or OK
+            False or True
         """
         if (ant is not None) and (not isinstance(ant, int)):
             self.logger.error("Invalid `ant` argument. Should be integer or None")
@@ -457,7 +454,7 @@ class HeraCorrCM(object):
             ant (integer): HERA antenna number to switch to noise. Set to None to
                            switch all antennas.
         returns:
-            ERROR or OK
+            False or True
         """
         self.antenna_enable(ant=ant)
 
@@ -469,7 +466,7 @@ class HeraCorrCM(object):
             ant (integer): HERA antenna number to switch to load. Set to None to
                            switch all antennas.
         returns:
-            ERROR or OK
+            False or True
         """
         if (ant is not None) and (not isinstance(ant, int)):
             self.logger.error("Invalid `ant` argument. Should be integer or None")
@@ -494,7 +491,7 @@ class HeraCorrCM(object):
             ant (integer): HERA antenna number to switch to noise. Set to None to
                            switch all antennas.
         returns:
-            ERROR or OK
+            False or True
         """
         self.antenna_enable(ant=ant)
 
@@ -527,7 +524,7 @@ class HeraCorrCM(object):
             pol (string): Polarization to query (must be 'e' or 'n')
             coeffs (numpy.array): Coefficients to load.
         returns:
-            ERROR or OK
+            False or True
         """
         coeffs_list = coeffs.tolist()
         sent_message = self._send_message("snap_eq", ant=ant, pol=pol, coeffs=coeffs_list)
@@ -547,7 +544,7 @@ class HeraCorrCM(object):
             pol (string): Polarization to query (must be 'e' or 'n')
         returns:
             time (UNIX timestamp float), coefficients (numpy array of floats)
-            or ERROR, in the case of a failure
+            or False, in the case of a failure
         """
         try:
             v = {key.decode(): val.decode() for key, val in self.r.hgetall('eq:ant:{ant:d}:{pol}'
@@ -575,7 +572,7 @@ class HeraCorrCM(object):
             ant (integer): HERA antenna number to query
             pol (string): Polarization to query (must be 'e' or 'n')
         returns:
-            ERROR, or attenuation value in dB (integer)
+            False, or attenuation value in dB (integer)
         """
         sent_message = self._send_message("pam_atten", ant=ant, pol=pol, rw="r")
         if sent_message is None:
@@ -596,7 +593,7 @@ class HeraCorrCM(object):
             pol (string): Polarization to query (must be 'e' or 'n')
             atten (integer): Attenuation value in dB
         returns:
-            OK or ERROR
+            False or True
         """
         sent_message = self._send_message("pam_atten", ant=ant, pol=pol, rw="w", val=atten)
         if sent_message is None:
@@ -842,6 +839,6 @@ class HeraCorrCM(object):
         """
         Run a correlator test using inbuilt test vector generators.
 
-        Will take a few minutes to run. Returns OK or ERROR.
+        Will take a few minutes to run. Returns True or False.
         """
         raise NotImplementedError("No code in run_correlator_test")

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -99,6 +99,13 @@ class HeraCorrCM(object):
                 time.sleep(1)
                 continue
 
+            try:
+                response = json.loads(command_status[b"args"])
+            except KeyError:
+                self.logger.warning("Improperly formatted response received. Trying again.")
+                time.sleep(1)
+                continue
+
             if (command_status[b"command"] == target_cmd) and (
                 float(command_status[b"time"]) == target_time
             ):
@@ -110,11 +117,12 @@ class HeraCorrCM(object):
                         continue
                 elif command_status[b"status"] == b"errored":
                     self.logger.error("Command {} errored on execution.".format(target_cmd))
-                    if b"err" in command_status[b"args"]:
-                        self.logger.error(command_status[b"err"])
+                    # do not need byte casting here because json.loads call does proper string handling
+                    if "err" in response:
+                        self.logger.error(response["err"])
                     return
                 elif command_status[b"status"] == b"complete":
-                    return command_status[b"args"]
+                    return response
 
             elif (command_status[b"command"] != target_cmd) or (
                 command_status[b"status"] in [b"completed", b"errored"]

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -95,7 +95,7 @@ class HeraCorrCM(object):
                     "This should not happen durring command execution. "
                     "Someone may have manually deleted it."
                 )
-                self.logger.error("Timed out waiting for a correlator response")
+                self.logger.error("Unknown Command Status dict state.")
                 return
             # try:
             #     message = json.loads(message["data"])
@@ -103,22 +103,22 @@ class HeraCorrCM(object):
             #     self.logger.warning("Got a non-JSON message on the correlator response channel")
             #     continue
 
-            if (command_status["command"] == target_cmd) and (
-                command_status["time"] == target_time
+            if (command_status[b"command"] == target_cmd) and (
+                command_status[b"time"] == target_time
             ):
-                if command_status["status"] == "running":
+                if command_status[b"status"] == b"running":
                     if timeout is not None and time.time() - wait_time > timeout:
                         self.logger.error("Timed out waiting for a correlator response")
                         return
                     else:
                         continue
-                elif command_status["status"] == "errored":
+                elif command_status[b"status"] == b"errored":
                     self.logger.error("Command {} errored on execution.".format(target_cmd))
-                    if "err" in command_status["args"]:
-                        self.logger.error(command_status["err"])
+                    if b"err" in command_status[b"args"]:
+                        self.logger.error(command_status[b"err"])
                     return
-                elif command_status["status"] == "complete":
-                    return command_status["args"]
+                elif command_status[b"status"] == b"complete":
+                    return command_status[b"args"]
 
             else:
                 self.logger.warning("Received a correlator response that wasn't meant for us")

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -18,10 +18,6 @@ SNAP_ENVIRONMENT = "venv"
 X_HOSTS = ["px%d" % i for i in range(1, 17)]
 X_PIPES = 2
 
-ERROR = False
-OK = True
-
-
 class HeraCorrHandler(object):
     """Correlator Handler."""
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -64,8 +64,10 @@ class HeraCorrHandler(object):
             "status": status,
             "update_time": time.time(),
         }
-        # clear out the status dict from last command
-        self.r.hdel("corr:cmd_status", *self.r.hkeys("corr:cmd_status"))
+        # bool(empty dict) is false.
+         # If it is not empy, clear out the status dict from last command
+        if not bool(self.r.hgetall("corr:cmd_status")):
+            self.r.hdel("corr:cmd_status", *self.r.hkeys("corr:cmd_status"))
 
         self.r.hmset("corr:cmd_status", command_status)
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -60,7 +60,7 @@ class HeraCorrHandler(object):
         command_status = {
             "command": command,
             "time": time,
-            "args": kwargs,
+            "args": json.dumps(kwargs),
             "status": status,
             "update_time": time.time(),
         }
@@ -69,11 +69,21 @@ class HeraCorrHandler(object):
 
         self.r.hmset("corr:cmd_status", command_status)
 
-    def _update_status(self, status):
+    def _update_status(self, status, **kwargs):
         command_status = {
             "status": status,
             "update_time": time.time(),
         }
+
+        # some corr_f commands return "err"
+        # want to be able to update the args dict
+        args = self.r.hget("corr:cmd_status", "args")
+        args = json.loads(args)
+        args.update(kwargs)
+
+        args = json.dumps(args)
+        command_status["args"] = args
+
         if status == "complete":
             command_status["completion_time"] = time.time()
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -33,7 +33,7 @@ class HeraCorrHandler(object):
         self.testmode = testmode
 
         self.cm = HeraCorrCM(redishost=self.redishost, include_fpga=False)
-        self.r = redis.Redis(self.redishost)
+        self.r = redis.Redis(self.redishost, decode_responses=True)
 
         # store the last time a command was received in unix time in seconds
         self.last_command_time = None

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -317,7 +317,7 @@ class HeraCorrHandler(object):
         self.logger.info("       args: {args:s}".format(args=args))
         if command == "record":
             starttime = float(self.r["corr:trig_time"]) * 1000  # Send in ms
-            self._create_status(command, time, status="running", starttime=starttime)
+            self._create_status(command, command_time, status="running", starttime=starttime)
 
             if not self.testmode:
                 self._start_capture(args["starttime"],

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -312,8 +312,7 @@ class HeraCorrHandler(object):
         self.logger.info("Got command: {cmd:s}".format(cmd=command))
         self.logger.info("       args: {args:s}".format(args=args))
         if command == "record":
-            starttime = float(self.r["corr:trig_time"]) * 1000  # Send in ms
-            self._create_status(command, command_time, status="running", starttime=starttime)
+            self._create_status(command, command_time, status="running", **args)
 
             if not self.testmode:
                 self._start_capture(args["starttime"],
@@ -321,22 +320,22 @@ class HeraCorrHandler(object):
                                     args["acclen"],
                                     args["tag"]
                                     )
-            self._update_status(status="complete")
-
+            starttime = float(self.r["corr:trig_time"]) * 1000  # Send in ms
+            self._update_status(status="complete", starttime=starttime)
         elif command == "stop":
-            self._create_status(command, command_time, status="running")
+            self._create_status(command, command_time, status="running", **args)
             if not self.testmode:
                 self._stop_capture()
             self._update_status(status="complete")
 
         elif command == "hard_stop":
-            self._create_status(command, command_time, status="running")
+            self._create_status(command, command_time, status="running", **args)
             if not self.testmode:
                 self._xtor_down()
             self._update_status(status="complete")
 
         elif command == "start":
-            self._create_status(command, command_time, status="running")
+            self._create_status(command, command_time, status="running", **args)
             if not self.testmode:
                 self._xtor_up()
             self._update_status(status="complete")

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -341,4 +341,4 @@ class HeraCorrHandler(object):
             self._create_status(command, time, status="running")
             if not self.testmode:
                 self._xtor_up()
-            self._update_status(command, time, status="complete")
+            self._update_status(status="complete")

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -56,10 +56,10 @@ class HeraCorrHandler(object):
 
         return
 
-    def _create_status(self, command, time, status, **kwargs):
+    def _create_status(self, command, command_time, status, **kwargs):
         command_status = {
             "command": command,
-            "time": time,
+            "time": command_time,
             "args": json.dumps(kwargs),
             "status": status,
             "update_time": time.time(),
@@ -309,7 +309,7 @@ class HeraCorrHandler(object):
     def _cmd_handler(self, message):
         d = json.loads(message)
         command = d["command"]
-        time = d["time"]
+        command_time = d["time"]
         args = d["args"]
         self.logger.info("Got command: {cmd:s}".format(cmd=command))
         self.logger.info("       args: {args:s}".format(args=args))
@@ -326,19 +326,19 @@ class HeraCorrHandler(object):
             self._update_status(status="complete")
 
         elif command == "stop":
-            self._create_status(command, time, status="running")
+            self._create_status(command, command_time, status="running")
             if not self.testmode:
                 self._stop_capture()
             self._update_status(status="complete")
 
         elif command == "hard_stop":
-            self._create_status(command, time, status="running")
+            self._create_status(command, command_time, status="running")
             if not self.testmode:
                 self._xtor_down()
             self._update_status(status="complete")
 
         elif command == "start":
-            self._create_status(command, time, status="running")
+            self._create_status(command, command_time, status="running")
             if not self.testmode:
                 self._xtor_up()
             self._update_status(status="complete")

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -65,8 +65,8 @@ class HeraCorrHandler(object):
             "update_time": time.time(),
         }
         # bool(empty dict) is false.
-         # If it is not empy, clear out the status dict from last command
-        if not bool(self.r.hgetall("corr:cmd_status")):
+        # If it is not empy, clear out the status dict from last command
+        if bool(self.r.hgetall("corr:cmd_status")):
             self.r.hdel("corr:cmd_status", *self.r.hkeys("corr:cmd_status"))
 
         self.r.hmset("corr:cmd_status", command_status)

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -179,14 +179,10 @@ class HeraCorrHandler(object):
         self.logger.info("Issuing hera_catcher_down.sh")
         proc2 = Popen(["hera_catcher_down.sh"])
         proc2.wait()
-        if int(proc2.returncode) != 0:
-            self._update_status(status="errored")
 
         self.logger.info("Issuing xtor_down.sh")
         proc1 = Popen(["xtor_down.sh"])
         proc1.wait()
-        if int(proc1.returncode) != 0:
-            self._update_status(status="errored")
 
 
     def _xtor_up(self, input_power_target=None, output_rms_target=None):

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -173,7 +173,7 @@ class HeraCorrHandler(object):
         proc.wait()
         if int(proc.returncode) != 0:
             self._update_status(status="errored")
-            return ERROR
+            return False
         self._update_status(status="complete")
         return
 
@@ -210,7 +210,7 @@ class HeraCorrHandler(object):
         if int(proc3.returncode) != 0:
             self.logger.error("Error running hera_snap_feng_init.py")
             self._update_status(status="errored")
-            return ERROR
+            return False
         self.logger.info("Issuing hera_snap_feng_init.py -s -e --noredistapcp")
         # In order to synchonize properly with many SNAPs in the system,
         # we need to multithread the arming of the syncs:
@@ -224,7 +224,7 @@ class HeraCorrHandler(object):
         if int(proc3.returncode) != 0:
             self.logger.error("Error running hera_snap_feng_init.py -s")
             self._update_status(status="errored")
-            return ERROR
+            return False
         if input_power_target is not None:
             self.logger.info("Issuing input balance "
                              "with target {pow:f}".format(pow=input_power_target)
@@ -242,7 +242,7 @@ class HeraCorrHandler(object):
             if int(proc3.returncode) != 0:
                 self.logger.error("Error running hera_snap_input_power_eq.py")
                 self._update_status(status="errored")
-                return ERROR
+                return False
         if output_rms_target is not None:
             self.logger.info("Issuing output balance "
                              "with target {rms:f}".format(rms=output_rms_target)
@@ -259,7 +259,7 @@ class HeraCorrHandler(object):
             if int(proc3.returncode) != 0:
                 self.logger.error("Error running hera_snap_output_power_eq.py")
                 self._update_status(status="errored")
-                return ERROR
+                return False
 
         self.logger.info("Issuing xtor_up.py --runtweak px{1..16}")
         proc1 = Popen(["xtor_up.py", "--runtweak", "--redislog"] + X_HOSTS)
@@ -269,14 +269,14 @@ class HeraCorrHandler(object):
         proc2.wait()
         if int(proc1.returncode) != 0:
             self._update_status(status="errored")
-            return ERROR
+            return False
 
         if int(proc2.returncode) != 0:
             self._update_status(status="errored")
-            return ERROR
+            return False
 
         self._update_status(status="complete")
-        return OK
+        return True
 
     def _stop_capture(self):
         self.logger.info("Stopping correlator")

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -320,7 +320,7 @@ class HeraCorrHandler(object):
         command_time = d["time"]
         args = d["args"]
         self.logger.info("Got command: {cmd:s}".format(cmd=command))
-        self.logger.info("       args: {args:s}".format(args=args))
+        self.logger.info("       args: {args}".format(args=args))
         if command == "record":
             self._create_status(command, command_time, status="running", **args)
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -13,7 +13,8 @@ from .hera_corr_cm import HeraCorrCM
 CATCHER_HOST = "hera-sn1"
 SNAP_HOST = "hera-snap-head"
 SNAP_USER = "hera"
-SNAP_ENVIRONMENT = "~/.venv/bin/activate"
+# SNAP_ENVIRONMENT = "~/.venv/bin/activate"
+SNAP_ENVIRONMENT = "venv"
 X_HOSTS = ["px%d" % i for i in range(1, 17)]
 X_PIPES = 2
 
@@ -202,7 +203,7 @@ class HeraCorrHandler(object):
         # --nomultithread boots snaps one at a time to avoid a rush on redis traffic also
         proc3 = Popen(["ssh",
                        "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
-                       "source", SNAP_ENVIRONMENT,
+                       "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,
                        "&&",
                        "hera_snap_feng_init.py",
                        "-p", "-i", "--noredistapcp", "--nomultithread"])
@@ -216,7 +217,7 @@ class HeraCorrHandler(object):
         # we need to multithread the arming of the syncs:
         proc3 = Popen(["ssh",
                        "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
-                       "source", SNAP_ENVIRONMENT,
+                       "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,
                        "&&",
                        "hera_snap_feng_init.py",
                        "-s", "-e", "--noredistapcp"])
@@ -231,7 +232,7 @@ class HeraCorrHandler(object):
                              )
             proc3 = Popen(["ssh",
                            "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
-                           "source", SNAP_ENVIRONMENT,
+                           "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,
                            "&&",
                            "hera_snap_input_power_eq.py",
                            "-e", "{pow:f}".format(pow=input_power_target),
@@ -249,7 +250,7 @@ class HeraCorrHandler(object):
                              )
             proc3 = Popen(["ssh",
                            "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
-                           "source", SNAP_ENVIRONMENT,
+                           "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,
                            "&&",
                            "hera_snap_output_power_eq.py",
                            "--rms", "{rms:f}".format(rms=output_rms_target)

--- a/hera_corr_cm/redis_cm.py
+++ b/hera_corr_cm/redis_cm.py
@@ -61,7 +61,7 @@ def get_snaps_from_redis():
     """Read SNAPs from redis - from CM, config and correlator viewpoints."""
     import yaml
 
-    r = redis.Redis('redishost', , decode_responses=True)
+    r = redis.Redis('redishost', decode_responses=True)
     snaps_cm_list = list(json.loads(r.hget('corr:map', 'all_snap_inputs')).keys())
     snap_to_host = json.loads(r.hget('corr:map', 'snap_host'))
     snaps = {'cm': [], 'cfg': [], 'corr': []}

--- a/hera_corr_cm/redis_cm.py
+++ b/hera_corr_cm/redis_cm.py
@@ -32,7 +32,7 @@ def write_snap_hostnames_to_redis(redishost='redishost'):
     This allows hera_mc to map hostnames to SNAP part numbers.
     """
     if isinstance(redishost, str):
-        redishost = redis.Redis(redishost)
+        redishost = redis.Redis(redishost, decode_responses=True)
     snap_host = {}
     snap_list = list(json.loads(redishost.hget('corr:map', 'all_snap_inputs')).keys())
     for snap in snap_list:
@@ -61,7 +61,7 @@ def get_snaps_from_redis():
     """Read SNAPs from redis - from CM, config and correlator viewpoints."""
     import yaml
 
-    r = redis.Redis('redishost')
+    r = redis.Redis('redishost', , decode_responses=True)
     snaps_cm_list = list(json.loads(r.hget('corr:map', 'all_snap_inputs')).keys())
     snap_to_host = json.loads(r.hget('corr:map', 'snap_host'))
     snaps = {'cm': [], 'cfg': [], 'corr': []}
@@ -78,7 +78,7 @@ def get_snaps_from_redis():
 def read_maps_from_redis(redishost='redishost'):
     """Read subset of corr:map."""
     if isinstance(redishost, str):
-        redishost = redis.Redis(redishost)
+        redishost = redis.Redis(redishost, decode_responses=True)
     if not redishost.exists('corr:map'):
         return None
     x = redishost.hgetall('corr:map')
@@ -121,7 +121,7 @@ def read_cminfo_from_redis(return_as, redishost='redishost'):
 
     cminfo = {}
 
-    redis_pool = redis.ConnectionPool(host=redishost)
+    redis_pool = redis.ConnectionPool(host=redishost, decode_responses=True)
     redishost = redis.Redis(connection_pool=redis_pool)
 
     cminfo_redis = redishost.hgetall("cminfo")

--- a/hera_today/hera_redis_to_html_columns.py
+++ b/hera_today/hera_redis_to_html_columns.py
@@ -22,7 +22,7 @@ def end_column():
   return '</div>'
 
 
-r = redis.Redis('localhost')
+r = redis.Redis('localhost', decode_responses=True)
 
 html_header = """
 <head>

--- a/hera_today/redis_autocorr_to_html.py
+++ b/hera_today/redis_autocorr_to_html.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 # Two redis instances run on this server.
 # port 6379 is the hera-digi mirror
 # port 6380 is the paper1 mirror
-r = redis.Redis('localhost', 6379)
+r = redis.Redis('localhost', 6379, decode_responses=True)
 
 n_ants = 192
 # Generate frequency axis

--- a/scripts/hera_corr_cmd_handler.py
+++ b/scripts/hera_corr_cmd_handler.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import socket
+import time
 hostname = socket.gethostname()
 
 if __name__ == "__main__":
@@ -20,6 +21,8 @@ if __name__ == "__main__":
     script_redis_key = "status:script:{host:s}:{file:s}".format(host=hostname, file=__file__)
 
     while(True):
+        # sleep for 1s between each attempt
+        time.sleep(1)
         # Set an expiring redis key so we know if this script dies
         handler.r.set(script_redis_key, "alive", ex=30)
         handler.process_command()

--- a/scripts/stdin_to_redis.py
+++ b/scripts/stdin_to_redis.py
@@ -17,7 +17,7 @@ def main():
                         help ='Channel to which stdin should be published.')
     args = parser.parse_args()
 
-    r = redis.Redis(args.redishost)
+    r = redis.Redis(args.redishost, decode_responses=True)
 
     # Get this machines hostname to prepend to the log message
     myhost = socket.gethostname()


### PR DESCRIPTION
A rather large update to how the call/response works and status tracking of commands.

Instead of using a pubsub channel to listen for a response, a redis hash is used to track execution time, status among other things. Errors can be moved up from the correlator commands via the status key as well. 

Currently running on site. Recommend additional testing for stability. 