### PR TITLE
Do not cast response values as bytes

### DIFF
--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -81,13 +81,13 @@ class HeraCorrCM(object):
             self.logger.error("Failed to decode sent command")
         # time is probably a float, but will cast as a str for exact comparison
         target_time = str(sent_message["time"])
-        if not isinstance(target_time, bytes):
-            target_time = target_time.encode()
+        # there is some python 2 vs 3 tension here. Force unicode to be consistent
+        if isinstance(target_time, bytes):
+            target_time = target_time.decode("utf-8")
 
         target_cmd = sent_message["command"]
-        # there is some python 2 vs 3 tension here. Force bytes to be consistent
-        if not isinstance(target_cmd, bytes):
-            target_cmd = target_cmd.encode()
+        if isinstance(target_cmd, bytes):
+            target_cmd = target_cmd.decode("utf-8")
         wait_time = time.time()
         # This loop only gets activated if we get a response which
         # isn't for us.

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -82,6 +82,7 @@ class HeraCorrCM(object):
         # time is probably a float, but will cast as a str for exact comparison
         target_time = str(sent_message["time"])
         # there is some python 2 vs 3 tension here. Force unicode to be consistent
+        # with decode_responses, redis is returning unicode str for entries and keys.
         if isinstance(target_time, bytes):
             target_time = target_time.decode("utf-8")
 

--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -201,8 +201,7 @@ class HeraCorrHandler(object):
                        "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
                        "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,
                        "&&",
-                       "hera_snap_feng_init.py",
-                       "-P", "-i", "-s", "-e", "--noredistapcp", "--nomultithread"])
+                       "hera_snap_feng_init.py", "-P", "-i", "-s", "-e"])
         proc3.wait()
         if int(proc3.returncode) != 0:
             self.logger.error("Error running hera_snap_feng_init.py")


### PR DESCRIPTION
Looks like two competing solutions to the bytes vs unicode issue was implemented in the last overhaul of this code. 

The `_get_response` was forcing the sent message values to be bytes, but with `deconde_response` on redis, even in python 2 the `command_status` would have unicode strings. This obviously creates tension when trying to compare the bytes-casted `target_time` with the unicode `command_status["time"]`.

Did some preliminary testing sending bogus `stop` commands when the correlator was off and got responses back fine. Needs further testing once snaps are online.