### PR TITLE
Leave SNAPS on

### DIFF
--- a/hera_corr_cm/hera_corr_handler.py
+++ b/hera_corr_cm/hera_corr_handler.py
@@ -193,7 +193,7 @@ class HeraCorrHandler(object):
         """
         # -p is used to not re-initialize all snaps. Array is on 100% 01 SEP 2020
         # -i initializes snap boards that are not already initialized
-        self.logger.info("Issuing hera_snap_feng_init.py -p -i --noredistapcp --nomultithread")
+        self.logger.info("Issuing hera_snap_feng_init.py -p -i")
         proc3 = Popen(["ssh",
                        "{user:s}@{host:s}".format(user=SNAP_USER, host=SNAP_HOST),
                        "source", "/home/hera/anaconda2/bin/activate", SNAP_ENVIRONMENT,


### PR DESCRIPTION
Recently there was a desire to leave the snaps on 24/7 since it is cooler at the array site. This breaks the init up to use `-pi` to not program/init snaps if they are already up. Also re-breaks up the sync/eth stage so that always happens on turn on.