### PR TITLE
Redo snap redis mon

### DIFF
--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -364,6 +364,8 @@ class HeraCorrCM(object):
             for pol, hostinfo in vals.items():
                 antpol = "{}:{}".format(ant, pol)
                 host = hostinfo['host']
+                if host not in stats:
+                    continue
                 stream = hostinfo['channel']
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream}

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -369,7 +369,7 @@ class HeraCorrCM(object):
                                       'fft_of': stats[host]['fft_overflow'] == 'True',
                                       'timestamp': timestamp}
                 for key, conv in conv_methods_by_ant.items():
-                    devid = conv[0].replace('{$PF}', antid)
+                    devid = conv[0].replace('{$PF}', str(antid))
                     try:
                         ant_status[antpol][key] = conv[1](stats[host][devid])
                     except:  # noqa

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -361,20 +361,20 @@ class HeraCorrCM(object):
                 stream = vals[pol]['channel']
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream,
-                                      'clip_count': int(stats['eq_clip_count']),
-                                      'fft_of': stats['fft_overflow'] == 'True',
-                                      'timestamp': dateutil.parser.parse(stats['timestamp'])}
+                                      'clip_count': int(stats[host]['eq_clip_count']),
+                                      'fft_of': stats[host]['fft_overflow'] == 'True',
+                                      'timestamp': dateutil.parser.parse(stats[host]['timestamp'])}
                 for key, conv in conv_methods_by_ant.items():
                     devid = conv[0].replace('{$PF}', antid)
                     try:
-                        ant_status[antpol][key] = conv[1](stats[devid])
+                        ant_status[antpol][key] = conv[1](stats[host][devid])
                     except:  # noqa
                         ant_status[key] = 'None'
                 for key, conv in conv_methods_by_stream.items():
                     devid = conv[0].replace('{$STREAM}', stream)
                     devid = devid.replace('{$PF}', antid).replace('{$POL}', pol)
                     try:
-                        ant_status[key] = conv[1](stats[devid])
+                        ant_status[key] = conv[1](stats[host][devid])
                     except:  # noqa
                         ant_status[key] = 'None'
 

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -361,9 +361,8 @@ class HeraCorrCM(object):
                 stream = vals[pol]['channel']
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream}
-                print(antpol, host, stream)
+                print(antpol, host, stream, antid)
                 for key, conv in conv_func.items():
-                    print(key, conv)
                     devid = conv[0].replace('{$STREAM}', str(stream))
                     devid = devid.replace('{$PF}', str(antid)).replace('{$POL}', pol)
                     try:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -358,8 +358,8 @@ class HeraCorrCM(object):
                 antpol = "{}:{}".format(ant, pol)
                 ant_status[antpol] = {}
                 host = vals[pol]['host']
-                stream = vals[pol]['channel']
-                antid = stream // 2
+                stream = str(vals[pol]['channel'])
+                antid = str(stream // 2)
                 try:
                     timestamp = dateutil.parser.parse(stats[host]['timestamp'])
                 except KeyError:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -378,11 +378,13 @@ class HeraCorrCM(object):
         Values of this dictionary are status key/val pairs.
 
         These keys are:
-            eq_coeffs (list of floats) : Digital EQ coefficients for this antenna
+            eq_coeffs (list of floats) : Digital EQ coefficients for this host
             histogram (list of ints) : Two-dim list: [[bin_centers][counts]] represent ADC histogram
             autocorrelation (list of floats) : Autocorrelation spectrum
             timestamp (datetime) : Asynchronous timestamp that these status entries were gathered
-
+            mean (float): mean of power for this host:stream
+            rms (float): rms of power for this host:stream
+            power (float): total power for this host:stream
             Unknown values return the string "None"
         """
         stats = self._get_status_keys("snap")

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -327,7 +327,6 @@ class HeraCorrCM(object):
         ant_to_snap = hookup['ant_to_snap']
         stats = self._get_status_keys("snap")
         conv_func = {
-            'host_ant_id': ("{$STREAM}", int),
             'adc_mean': ('stream{$STREAM}_mean', float),
             'adc_rms': ('stream{$STREAM}_mean', float),
             'adc_power': ('stream{$STREAM}_mean', float),

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -328,12 +328,12 @@ class HeraCorrCM(object):
         stats = self._get_status_keys("snap")
         conv_func = {
             'adc_mean': ('stream{$STREAM}_mean', float),
-            'adc_rms': ('stream{$STREAM}_mean', float),
-            'adc_power': ('stream{$STREAM}_mean', float),
+            'adc_rms': ('stream{$STREAM}_rms', float),
+            'adc_power': ('stream{$STREAM}_power', float),
             'pam_atten': ('pam{$PF}_atten_{$POL}', int),
             'pam_power': ('pam{$PF}_power_{$POL}', float),
-            'pam_voltage': ('pam{$PF}_voltage_{$POL}', float),
-            'pam_current': ('pam{$PF}_current_{$POL}', float),
+            'pam_voltage': ('pam{$PF}_voltage', float),
+            'pam_current': ('pam{$PF}_current', float),
             'eq_coeffs': ('stream{$STREAM}_eq_coeffs', json.loads),
             'histogram': ('stream{$STREAM}_hist', json.loads),
             'autocorrelation': ('stream{$STREAM}_autocorr', json.loads),
@@ -347,7 +347,7 @@ class HeraCorrCM(object):
             'fem_id': ('fem{$PF}_id', json.loads),
             'fem_switch': ('fem{$PF}_switch', str),
             'fem_imu_theta': ('fem{$PF}_imu_theta', float),
-            'fem_imu_phi': ('fem{$PF}_imu_theta', float),
+            'fem_imu_phi': ('fem{$PF}_imu_phi', float),
             'timestamp': ('timestamp', dateutil.parser.parse),
             'clip_count': ('eq_clip_count', int),
             'fft_of': ('fft_overflow', lambda x: (x == 'True'))

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -360,10 +360,14 @@ class HeraCorrCM(object):
                 host = vals[pol]['host']
                 stream = vals[pol]['channel']
                 antid = stream // 2
+                try:
+                    timestamp = dateutil.parser.parse(stats[host]['timestamp'])
+                except KeyError:
+                    continue
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream,
                                       'clip_count': int(stats[host]['eq_clip_count']),
                                       'fft_of': stats[host]['fft_overflow'] == 'True',
-                                      'timestamp': dateutil.parser.parse(stats[host]['timestamp'])}
+                                      'timestamp': timestamp}
                 for key, conv in conv_methods_by_ant.items():
                     devid = conv[0].replace('{$PF}', antid)
                     try:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -358,8 +358,8 @@ class HeraCorrCM(object):
                 antpol = "{}:{}".format(ant, pol)
                 ant_status[antpol] = {}
                 host = vals[pol]['host']
-                stream = str(vals[pol]['channel'])
-                antid = str(stream // 2)
+                stream = vals[pol]['channel']
+                antid = stream // 2
                 try:
                     timestamp = dateutil.parser.parse(stats[host]['timestamp'])
                 except KeyError:
@@ -375,8 +375,8 @@ class HeraCorrCM(object):
                     except:  # noqa
                         ant_status[key] = 'None'
                 for key, conv in conv_methods_by_stream.items():
-                    devid = conv[0].replace('{$STREAM}', stream)
-                    devid = devid.replace('{$PF}', antid).replace('{$POL}', pol)
+                    devid = conv[0].replace('{$STREAM}', str(stream))
+                    devid = devid.replace('{$PF}', str(antid)).replace('{$POL}', pol)
                     try:
                         ant_status[key] = conv[1](stats[host][devid])
                     except:  # noqa

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -253,12 +253,23 @@ class HeraCorrCM(object):
         Keys of returned dictionaries are snap hostnames. Values of this dictionary are
         status key/val pairs.
 
+        For the conv_info dictionary, the format is:
+            key: name of the variable in the return dictionary from this method
+            tuple:  (redis key name, conversion method from redis to this method).
+
         These keys are:
-            pmb_alert (bool) : True if SNAP PSU controllers have issued an alert. False otherwise.
-            pps_count (int)  : Number of PPS pulses received since last programming cycle
-            serial (str)     : Serial number of this SNAP board
-            temp (float)     : Reported FPGA temperature (degrees C)
-            uptime (int)     : Multiples of 500e6 ADC clocks since last programming cycle
+            is_programmed (bool): True if the host is programmed
+            adc_is_configured (bool): True if the host adc is configured
+            is_initialized (bool): True if host is initialized
+            dest_is_configured (bool): True if dest_is_configured
+            version (str)      : Version of firmware installed
+            sample_rate (float): Sample rate in MHz
+            input (str)        : comma-delimited list of stream inputs, e.g. adc,adc,adc,adc,adc,adc
+            pmb_alert (bool)   : True if SNAP PSU controllers have issued an alert. False otherwise.
+            pps_count (int)    : Number of PPS pulses received since last programming cycle
+            serial (str)       : Serial number of this SNAP board
+            temp (float)       : Reported FPGA temperature (degrees C)
+            uptime (int)       : Multiples of 500e6 ADC clocks since last programming cycle
             last_programmed (datetime) : Last time this FPGA was programmed
             timestamp (datetime) : Asynchronous timestamp that these status entries were gathered
 
@@ -297,6 +308,10 @@ class HeraCorrCM(object):
 
         Keys of returned dictionaries are of the form "<antenna number>:"<e|n>". Values of
         this dictionary are status key/val pairs.
+
+        For the conv_info dictionary, the format is:
+            key: name of the variable in the return dictionary from this method
+            tuple:  (redis key name, conversion method from redis to this method).
 
         These keys are:
             adc_mean (float)  : Mean ADC value (in ADC units)
@@ -386,9 +401,13 @@ class HeraCorrCM(object):
         Keys of returned dictionaries are of the form "<SNAP hostname>:"<SNAP input number>".
         Values of this dictionary are status key/val pairs.
 
+        For the conv_info dictionary, the format is:
+            key: name of the variable in the return dictionary from this method
+            tuple:  (redis key name, conversion method from redis to this method).
+
         These keys are:
             eq_coeffs (list of floats) : Digital EQ coefficients for this host
-            histogram (list of ints) : Two-dim list: [[bin_centers][counts]] represent ADC histogram
+            histogram (list of ints) : List of counts representing ADC histogram
             autocorrelation (list of floats) : Autocorrelation spectrum
             timestamp (datetime) : Asynchronous timestamp that these status entries were gathered
             mean (float): mean of power for this host:stream

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -406,6 +406,8 @@ class HeraCorrCM(object):
         """
         Return a dictionary of SNAP input stats.
 
+        This information is duplicated in ant_status, and this method is deprecated.
+
         These keys are:
             eq_coeffs (list of floats) : Digital EQ coefficients for this host
             histogram (list of ints) : List of counts representing ADC histogram

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -368,6 +368,7 @@ class HeraCorrCM(object):
                         ant_status[key] = conv[1](stats[host][devid])
                     except:  # noqa
                         ant_status[key] = 'None'
+        return ant_status
 
     def get_snaprf_status(self):
         """

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -361,7 +361,9 @@ class HeraCorrCM(object):
                 stream = vals[pol]['channel']
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream}
+                print(antpol, host, stream)
                 for key, conv in conv_func.items():
+                    print(key, conv)
                     devid = conv[0].replace('{$STREAM}', str(stream))
                     devid = devid.replace('{$PF}', str(antid)).replace('{$POL}', pol)
                     try:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -361,14 +361,13 @@ class HeraCorrCM(object):
                 stream = vals[pol]['channel']
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream}
-                print(antpol, host, stream, antid)
                 for key, conv in conv_func.items():
                     devid = conv[0].replace('{$STREAM}', str(stream))
                     devid = devid.replace('{$PF}', str(antid)).replace('{$POL}', pol)
                     try:
-                        ant_status[key] = conv[1](stats[host][devid])
+                        ant_status[antpol][key] = conv[1](stats[host][devid])
                     except:  # noqa
-                        ant_status[key] = 'None'
+                        ant_status[antpol][key] = 'Not Found'
         return ant_status
 
     def get_snaprf_status(self):

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -248,10 +248,7 @@ class HeraCorrCM(object):
 
     def get_f_status(self):
         """
-        Return a dictionary of snap status flags.
-
-        Keys of returned dictionaries are snap hostnames. Values of this dictionary are
-        status key/val pairs.
+        Return a dictionary of snap status values.
 
         These keys are:
             is_programmed (bool): True if the host is programmed
@@ -276,8 +273,9 @@ class HeraCorrCM(object):
 
         Returns
         -------
-        dict
-            keys are the parameter names to be stored, values are the parameter values
+        dict of dicts
+            keys of the outer dict are the snap hostnames, values are the key/value pairs
+            of the listed keys above.
         """
         stats = self._get_status_keys("snap")
         # For the conv_info dictionary below, the format is:
@@ -313,9 +311,6 @@ class HeraCorrCM(object):
         """
         Return a dictionary of antenna status flags.
 
-        Keys of returned dictionaries are of the form "<antenna number>:"<e|n>". Values of
-        this dictionary are status key/val pairs.
-
         These keys are:
             adc_mean (float)  : Mean ADC value (in ADC units)
             adc_rms (float)   : RMS ADC value (in ADC units)
@@ -348,8 +343,9 @@ class HeraCorrCM(object):
 
         Returns
         -------
-        dict
-            keys are the parameter names to be stored, values are the parameter values
+        dict of dicts
+            keys of the outer dict are of the form <ant number>:<pol> and values are the
+            key/value pairs of the listed keys above.
 
         """
         from . import redis_cm
@@ -410,9 +406,6 @@ class HeraCorrCM(object):
         """
         Return a dictionary of SNAP input stats.
 
-        Keys of returned dictionaries are of the form "<SNAP hostname>:"<SNAP input number>".
-        Values of this dictionary are status key/val pairs.
-
         These keys are:
             eq_coeffs (list of floats) : Digital EQ coefficients for this host
             histogram (list of ints) : List of counts representing ADC histogram
@@ -425,8 +418,9 @@ class HeraCorrCM(object):
 
         Returns
         -------
-        dict
-            keys are the parameter names to be stored, values are the parameter values
+        dict of dicts
+            keys of the outer dict are of the form <snap hostname>:<snap input number>, values
+            are the key/value pairs of the listed keys above.
         """
         stats = self._get_status_keys("snap")
         # For the conv_info dictionary below, the format is:


### PR DESCRIPTION
This updates hera_corr_cm to use just the one status:snap key in redis (so converts in ingest, not in the hera_corr_f daemon output).  It also plumbs through the remaining snap status keys.  This is not the new array format, but the incremental next step in the process.