### PR TITLE
add exception default values for ant_status

### DIFF
--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -311,7 +311,6 @@ class HeraCorrCM(object):
                 try:
                     f_status[host][key] = cfunc(stats[host][ckey].decode())
                 except Exception as e:
-                    # f_status[host][key] = "Exception: {}".format(str(e))
                     f_status[host][key] = None
         return f_status
 
@@ -412,14 +411,12 @@ class HeraCorrCM(object):
                             ant_status[antpol][key] = cfunc(stats[host][ckey], carg).astype(ccst)
                             not_exceptions += 1
                         except Exception as e:
-                            # ant_status[antpol][key] = "Exception: {}".format(str(e))
                             ant_status[antpol][key] = None
                     else:
                         try:
                             ant_status[antpol][key] = cfunc(stats[host][ckey].decode())
                             not_exceptions += 1
                         except Exception as e:
-                            # ant_status[antpol][key] = "Exception: {}".format(str(e))
                             ant_status[antpol][key] = None
                 if not_exceptions < 3:
                     del(ant_status[antpol])
@@ -473,13 +470,11 @@ class HeraCorrCM(object):
                         try:
                             rf_status[rfch][key] = cfunc(stats[host][ckey], carg).astype(ccst)
                         except Exception as e:
-                            # rf_status[rfch][key] = "Exception: {}".format(str(e))
                             rf_status[rfch][key] = None
                     else:
                         try:
                             rf_status[rfch][key] = cfunc(stats[host][ckey].decode())
                         except Exception as e:
-                            # rf_status[rfch][key] = "Exception: {}".format(str(e))
                             rf_status[rfch][key] = None
         return rf_status
 

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -320,7 +320,7 @@ class HeraCorrCM(object):
                     f_status[host][key] = cfunc(stats[host][ckey].decode())
                 except Exception as e:
                     # f_status[host][key] = "Exception: {}".format(str(e))
-                    f_status[host][key] = cexc
+                    f_status[host][key] = None
         return f_status
 
     def get_ant_status(self):
@@ -424,14 +424,14 @@ class HeraCorrCM(object):
                             not_exceptions += 1
                         except Exception as e:
                             # ant_status[antpol][key] = "Exception: {}".format(str(e))
-                            ant_status[antpol][key] = cexc
+                            ant_status[antpol][key] = None
                     else:
                         try:
                             ant_status[antpol][key] = cfunc(stats[host][ckey].decode())
                             not_exceptions += 1
                         except Exception as e:
                             # ant_status[antpol][key] = "Exception: {}".format(str(e))
-                            ant_status[antpol][key] = cexc
+                            ant_status[antpol][key] = None
                 if not_exceptions < 3:
                     del(ant_status[antpol])
         return ant_status
@@ -487,13 +487,13 @@ class HeraCorrCM(object):
                             rf_status[rfch][key] = cfunc(stats[host][ckey], carg).astype(ccst)
                         except Exception as e:
                             # rf_status[rfch][key] = "Exception: {}".format(str(e))
-                            rf_status[rfch][key] = cexc
+                            rf_status[rfch][key] = None
                     else:
                         try:
                             rf_status[rfch][key] = cfunc(stats[host][ckey].decode())
                         except Exception as e:
                             # rf_status[rfch][key] = "Exception: {}".format(str(e))
-                            rf_status[rfch][key] = cexc
+                            rf_status[rfch][key] = None
         return rf_status
 
     def get_x_status(self):

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -301,8 +301,8 @@ class HeraCorrCM(object):
             'serial': ('serial', str),
             'temp': ('temp', float),
             'uptime': ('uptime', int),
-            'last_programmed': ('last_programmed', dateutil.parser.parse,
-            'timestamp': ('timestamp', dateutil.parser.parse),
+            'last_programmed': ('last_programmed', dateutil.parser.parse),
+            'timestamp': ('timestamp', dateutil.parser.parse)
         }
         f_status = {}
         for host, val in stats.items():

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -13,14 +13,6 @@ import numpy as np
 from .handlers import add_default_log_handlers
 from . import __package__, __version__
 
-EXCEPTION_VALUE = {
-                   'str': 'unknown',
-                   'int': -1,
-                   'float': -1.0,
-                   'af32': np.array([-1.0], dtype=np.float32),
-                   'aint': np.array([-1], dtype=int)
-                   }
-
 # this is identical to six.string_type but we don't want six dependence
 if sys.version_info.major > 2:
     string_type = str
@@ -297,25 +289,25 @@ class HeraCorrCM(object):
         #     key: name of the variable in the return dictionary from this method
         #     tuple:  (redis key name, conversion method from redis to this method).
         conv_info = {
-            'is_programmed': ('is_programmed', lambda x: (x == 'True'), False),
-            'adc_is_configured': ('adc_is_configured', lambda x: (x == '1'), False),
-            'is_initialized': ('is_initialized', lambda x: (x == '1'), False),
-            'dest_is_configured': ('dest_is_configured', lambda x: (x == '1'), False),
-            'version': ('version', str, EXCEPTION_VALUE['str']),
-            'sample_rate': ('sample_rate', float, EXCEPTION_VALUE['float']),
-            'input': ('input', str, EXCEPTION_VALUE['str']),
-            'pmb_alert': ('pmb_alert', lambda x: bool(int(x)), False),
-            'pps_count': ('pps_count', int, EXCEPTION_VALUE['int']),
-            'serial': ('serial', str, EXCEPTION_VALUE['str']),
-            'temp': ('temp', float, EXCEPTION_VALUE['float']),
-            'uptime': ('uptime', int, EXCEPTION_VALUE['int']),
-            'last_programmed': ('last_programmed', dateutil.parser.parse, None),
-            'timestamp': ('timestamp', dateutil.parser.parse, None),
+            'is_programmed': ('is_programmed', lambda x: (x == 'True')),
+            'adc_is_configured': ('adc_is_configured', lambda x: (x == '1')),
+            'is_initialized': ('is_initialized', lambda x: (x == '1')),
+            'dest_is_configured': ('dest_is_configured', lambda x: (x == '1')),
+            'version': ('version', str),
+            'sample_rate': ('sample_rate', float),
+            'input': ('input', str),
+            'pmb_alert': ('pmb_alert', lambda x: bool(int(x))),
+            'pps_count': ('pps_count', int),
+            'serial': ('serial', str),
+            'temp': ('temp', float),
+            'uptime': ('uptime', int),
+            'last_programmed': ('last_programmed', dateutil.parser.parse,
+            'timestamp': ('timestamp', dateutil.parser.parse),
         }
         f_status = {}
         for host, val in stats.items():
             f_status[host] = {}
-            for key, (ckey, cfunc, cexc) in conv_info.items():
+            for key, (ckey, cfunc) in conv_info.items():
                 try:
                     f_status[host][key] = cfunc(stats[host][ckey].decode())
                 except Exception as e:
@@ -375,33 +367,30 @@ class HeraCorrCM(object):
         #              conversion method from redis to this method,
         #              arg for conversion method).
         conv_info = {
-            'adc_mean': ('stream{$CH}_mean', float, None, None, EXCEPTION_VALUE['float']),
-            'adc_rms': ('stream{$CH}_rms', float, None, None, EXCEPTION_VALUE['float']),
-            'adc_power': ('stream{$CH}_power', float, None, None, EXCEPTION_VALUE['float']),
-            'pam_atten': ('pam{$PF}_atten_{$POL}', int, None, None, EXCEPTION_VALUE['int']),
-            'pam_power': ('pam{$PF}_power_{$POL}', float, None, None, EXCEPTION_VALUE['float']),
-            'pam_voltage': ('pam{$PF}_voltage', float, None, None, EXCEPTION_VALUE['float']),
-            'pam_current': ('pam{$PF}_current', float, None, None, EXCEPTION_VALUE['float']),
-            'eq_coeffs': ('stream{$CH}_eq_coeffs', np.frombuffer,
-                          float, np.float32, EXCEPTION_VALUE['af32']),
-            'histogram': ('stream{$CH}_hist', np.frombuffer, int, int, EXCEPTION_VALUE['aint']),
-            'autocorrelation': ('stream{$CH}_autocorr', np.frombuffer,
-                                float, np.float32, EXCEPTION_VALUE['af32']),
-            'fem_lna_power': ('fem{$PF}_lna_power_{$POL}', lambda x: (x == 'True'),
-                              None, None, False),
-            'pam_id': ('pam{$PF}_id', json.loads, None, None, EXCEPTION_VALUE['str']),
-            'fem_temp': ('fem{$PF}_temp', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_voltage': ('fem{$PF}_voltage', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_current': ('fem{$PF}_current', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_pressure': ('fem{$PF}_pressure', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_humidity': ('fem{$PF}_humidity', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_id': ('fem{$PF}_id', json.loads, None, None, EXCEPTION_VALUE['str']),
-            'fem_switch': ('fem{$PF}_switch', str, None, None, EXCEPTION_VALUE['str']),
-            'fem_imu_theta': ('fem{$PF}_imu_theta', float, None, None, EXCEPTION_VALUE['float']),
-            'fem_imu_phi': ('fem{$PF}_imu_phi', float, None, None, EXCEPTION_VALUE['float']),
-            'timestamp': ('timestamp', dateutil.parser.parse, None, None, None),
-            'clip_count': ('eq_clip_count', int, None, None, EXCEPTION_VALUE['int']),
-            'fft_of': ('fft_overflow', lambda x: (x == 'True'), None, None, False)
+            'adc_mean': ('stream{$CH}_mean', float, None, None),
+            'adc_rms': ('stream{$CH}_rms', float, None, None),
+            'adc_power': ('stream{$CH}_power', float, None, None),
+            'pam_atten': ('pam{$PF}_atten_{$POL}', int, None, None),
+            'pam_power': ('pam{$PF}_power_{$POL}', float, None, None),
+            'pam_voltage': ('pam{$PF}_voltage', float, None, None),
+            'pam_current': ('pam{$PF}_current', float, None, None),
+            'eq_coeffs': ('stream{$CH}_eq_coeffs', np.frombuffer, float, np.float32),
+            'histogram': ('stream{$CH}_hist', np.frombuffer, int, int),
+            'autocorrelation': ('stream{$CH}_autocorr', np.frombuffer, float, np.float32),
+            'fem_lna_power': ('fem{$PF}_lna_power_{$POL}', lambda x: (x == 'True'), None, None),
+            'pam_id': ('pam{$PF}_id', json.loads, None, None),
+            'fem_temp': ('fem{$PF}_temp', float, None, None),
+            'fem_voltage': ('fem{$PF}_voltage', float, None, None),
+            'fem_current': ('fem{$PF}_current', float, None, None),
+            'fem_pressure': ('fem{$PF}_pressure', float, None, None),
+            'fem_humidity': ('fem{$PF}_humidity', float, None, None),
+            'fem_id': ('fem{$PF}_id', json.loads, None, None),
+            'fem_switch': ('fem{$PF}_switch', str, None, None),
+            'fem_imu_theta': ('fem{$PF}_imu_theta', float, None, None),
+            'fem_imu_phi': ('fem{$PF}_imu_phi', float, None, None),
+            'timestamp': ('timestamp', dateutil.parser.parse, None, None),
+            'clip_count': ('eq_clip_count', int, None, None),
+            'fft_of': ('fft_overflow', lambda x: (x == 'True'), None, None)
         }
         ant_status = {}
         for ant, vals in ant_to_snap.items():
@@ -414,7 +403,7 @@ class HeraCorrCM(object):
                 antid = stream // 2
                 ant_status[antpol] = {'f_host': host, 'host_ant_id': stream}
                 not_exceptions = 0
-                for key, (ckey, cfunc, carg, ccst, cexc) in conv_info.items():
+                for key, (ckey, cfunc, carg, ccst) in conv_info.items():
                     ckey = ckey.replace('{$CH}', str(stream))
                     ckey = ckey.replace('{$PF}', str(antid))
                     ckey = ckey.replace('{$POL}', pol)
@@ -464,15 +453,13 @@ class HeraCorrCM(object):
         #     key: name of the variable in the return dictionary from this method
         #     tuple:  (redis key name, conversion method from redis to this method).
         conv_info = {
-            'timestamp': ('timestamp', dateutil.parser.parse, None, None, None),
-            'mean': ('stream{$CH}_mean', float, None, None, EXCEPTION_VALUE['float']),
-            'rms': ('stream{$CH}_rms', float, None, None, EXCEPTION_VALUE['float']),
-            'power': ('stream{$CH}_power', float, None, None, EXCEPTION_VALUE['float']),
-            'eq_coeffs': ('stream{$CH}_eq_coeffs', np.frombuffer,
-                          float, np.float32, EXCEPTION_VALUE['af32']),
-            'histogram': ('stream{$CH}_hist', np.frombuffer, int, int, EXCEPTION_VALUE['aint']),
-            'autocorrelation': ('stream{$CH}_autocorr', np.frombuffer,
-                                float, np.float32, EXCEPTION_VALUE['af32']),
+            'timestamp': ('timestamp', dateutil.parser.parse, None, None),
+            'mean': ('stream{$CH}_mean', float, None, None),
+            'rms': ('stream{$CH}_rms', float, None, None),
+            'power': ('stream{$CH}_power', float, None, None),
+            'eq_coeffs': ('stream{$CH}_eq_coeffs', np.frombuffer, float, np.float32),
+            'histogram': ('stream{$CH}_hist', np.frombuffer, int, int),
+            'autocorrelation': ('stream{$CH}_autocorr', np.frombuffer, float, np.float32),
         }
 
         rf_status = {}
@@ -480,7 +467,7 @@ class HeraCorrCM(object):
             for stream in range(numch):
                 rfch = "{}:{}".format(host, stream)
                 rf_status[rfch] = {}
-                for key, (ckey, cfunc, carg, ccst, cexc) in conv_info.items():
+                for key, (ckey, cfunc, carg, ccst) in conv_info.items():
                     ckey = ckey.replace('{$CH}', str(stream))
                     if carg is not None:
                         try:

--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -250,7 +250,7 @@ class HeraCorrCM(object):
             rv[key.lstrip(keystart)] = self._hgetall(key, decode_responses=decode_responses)
         return rv
 
-    def _hgetall(self, rkey, decode_responses):
+    def _hgetall(self, rkey, decode_responses=True):
         """
         Generate a wrapper around self.r.hgetall(rkey).
 


### PR DESCRIPTION
This updates get_ant_status to return a dictionary that matches the expected data-types as in the psql table, instead of exception error strings if the conversion errored.  This makes get_ant_status even more clunky, but there is an issue already to improve the data-type handling.