### PR TITLE
Get the proper key for fem switch state

### DIFF
--- a/hera_corr_cm/hera_corr_cm.py
+++ b/hera_corr_cm/hera_corr_cm.py
@@ -161,9 +161,19 @@ class HeraCorrCM(object):
         md5 = self.r.hget("snap_configuration", "md5")
         return float(config_time), yaml.load(config, Loader=yaml.FullLoader), md5
 
+    def fem_switch_state(self):
+        """
+        Return FEM switch state and time.
+        """
+        x = self._hgetall("corr:fem_switch_state")
+        return x["state"], float(x["time"])
+
     def noise_diode_is_on(self):
         """
         Return if noise diode is on.
+
+        Deprecated -- this is left to not break things for now, but there is no
+        data in the key that this monitors after Feb 2021
 
         Returns: enable_state, UNIX timestamp (float) of last state change
         enable_state is True if noise diode is on. Else False.
@@ -174,6 +184,9 @@ class HeraCorrCM(object):
     def load_is_on(self):
         """
         Return if load is on.
+
+        Deprecated -- this is left to not break things for now, but there is no
+        data in the key that this monitors after Feb 2021
 
         Returns: enable_state, UNIX timestamp (float) of last state change
         enable_state is True if load is on. Else False.
@@ -242,7 +255,7 @@ class HeraCorrCM(object):
             rv[key.lstrip(keystart)] = self._hgetall(key, decode_responses=decode_responses)
         return rv
 
-    def _hgetall(self, rkey, decode_responses):
+    def _hgetall(self, rkey, decode_responses=True):
         """
         Generate a wrapper around self.r.hgetall(rkey).
 
@@ -302,7 +315,7 @@ class HeraCorrCM(object):
             'temp': ('temp', float),
             'uptime': ('uptime', int),
             'last_programmed': ('last_programmed', dateutil.parser.parse),
-            'timestamp': ('timestamp', dateutil.parser.parse),
+            'timestamp': ('timestamp', dateutil.parser.parse)
         }
         f_status = {}
         for host, val in stats.items():
@@ -311,7 +324,7 @@ class HeraCorrCM(object):
                 try:
                     f_status[host][key] = cfunc(stats[host][ckey].decode())
                 except Exception as e:
-                    f_status[host][key] = "Exception: {}".format(str(e))
+                    f_status[host][key] = None
         return f_status
 
     def get_ant_status(self):
@@ -411,13 +424,13 @@ class HeraCorrCM(object):
                             ant_status[antpol][key] = cfunc(stats[host][ckey], carg).astype(ccst)
                             not_exceptions += 1
                         except Exception as e:
-                            ant_status[antpol][key] = "Exception: {}".format(str(e))
+                            ant_status[antpol][key] = None
                     else:
                         try:
                             ant_status[antpol][key] = cfunc(stats[host][ckey].decode())
                             not_exceptions += 1
                         except Exception as e:
-                            ant_status[antpol][key] = "Exception: {}".format(str(e))
+                            ant_status[antpol][key] = None
                 if not_exceptions < 3:
                     del(ant_status[antpol])
         return ant_status
@@ -444,6 +457,7 @@ class HeraCorrCM(object):
             keys of the outer dict are of the form <snap hostname>:<snap input number>, values
             are the key/value pairs of the listed keys above.
         """
+
         stats = self._get_status_keys("snap")
         # For the conv_info dictionary below, the format is:
         #     key: name of the variable in the return dictionary from this method
@@ -469,12 +483,12 @@ class HeraCorrCM(object):
                         try:
                             rf_status[rfch][key] = cfunc(stats[host][ckey], carg).astype(ccst)
                         except Exception as e:
-                            rf_status[rfch][key] = "Exception: {}".format(str(e))
+                            rf_status[rfch][key] = None
                     else:
                         try:
                             rf_status[rfch][key] = cfunc(stats[host][ckey].decode())
                         except Exception as e:
-                            rf_status[rfch][key] = "Exception: {}".format(str(e))
+                            rf_status[rfch][key] = None
         return rf_status
 
     def get_x_status(self):


### PR DESCRIPTION
The previously used keys ("corr:status_noise_diode" and "corr:status_load") are still in redis but have not been updated since Feb. 2021